### PR TITLE
Use single quotes instead of double quotes

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -58,6 +58,7 @@ describe('Recap Handling', () => {
       let decoded: Recap;
       expect(() => (decoded = Recap.extract_and_verify(message))).not.toThrow();
       expect(decoded!.attenuations).toEqual(recap.att);
+      // @ts-ignore
       let proofs = recap.prf.map(CID.decode);
       // @ts-ignore
       expect(decoded.proofs).toEqual(proofs);

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -50,18 +50,14 @@ describe('Recap Handling', () => {
     for (const { message, recap } of Object.values(valid).map(
       // @ts-ignore
       ({ message, recap: { att, prf } }) => ({
-        // @ts-ignore
         message: new SiweMessage(message),
         // @ts-ignore
         recap: { att, prf: prf.map(CID.decode) },
       })
     )) {
-      let decoded;
-      // @ts-ignore
+      let decoded: Recap;
       expect(() => (decoded = Recap.extract_and_verify(message))).not.toThrow();
-      // @ts-ignore
-      expect(decoded.attenuations).toEqual(recap.att);
-      // @ts-ignore
+      expect(decoded!.attenuations).toEqual(recap.att);
       let proofs = recap.prf.map(CID.decode);
       // @ts-ignore
       expect(decoded.proofs).toEqual(proofs);

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,9 +77,9 @@ export class Recap {
         }, {} as { [key: string]: Array<string> });
 
       for (const [namespace, names] of Object.entries(resourceAbilities)) {
-        statement += `(${section}) "${namespace}": ${names
-          .map(n => '"' + n + '"')
-          .join(', ')} for "${resource}". `;
+        statement += `(${section}) '${namespace}': ${names
+          .map(n => `'${n}'`)
+          .join(', ')} for '${resource}'. `;
         section += 1;
       }
     }

--- a/test/valid.json
+++ b/test/valid.json
@@ -36,7 +36,7 @@
       "statement": "I further authorize the stated URI to perform the following actions on my behalf: (1) 'kv': 'get', 'list', 'metadata' for 'kepler:ens:example.eth://default/kv'. (2) 'kv': 'delete', 'get', 'list', 'metadata', 'put' for 'kepler:ens:example.eth://default/kv/dapp-space'. (3) 'kv': 'delete', 'get', 'list', 'metadata', 'put' for 'kepler:ens:example.eth://default/kv/public'. (4) 'credential': 'present' for 'urn:credential:type:type1'.",
       "uri": "did:key:example",
       "version": "1",
-      "chainId": "1",
+      "chainId": 1,
       "nonce": "mynonce1",
       "issuedAt": "2022-06-21T12:00:00.000Z",
       "resources": [
@@ -78,7 +78,7 @@
       "statement": "Some custom statement. I further authorize the stated URI to perform the following actions on my behalf: (1) 'credential': 'present' for 'credential:*'.",
       "uri": "did:key:example",
       "version": "1",
-      "chainId": "1",
+      "chainId": 1,
       "nonce": "mynonce1",
       "issuedAt": "2022-06-21T12:00:00.000Z",
       "resources": [

--- a/test/valid.json
+++ b/test/valid.json
@@ -3,7 +3,7 @@
     "message": {
       "domain": "example.com",
       "address": "0x0000000000000000000000000000000000000000",
-      "statement": "I further authorize the stated URI to perform the following actions on my behalf: (1) \"kv\": \"get\", \"list\", \"metadata\" for \"kepler:ens:example.eth://default/kv\". (2) \"kv\": \"delete\", \"get\", \"list\", \"metadata\", \"put\" for \"kepler:ens:example.eth://default/kv/dapp-space\". (3) \"kv\": \"delete\", \"get\", \"list\", \"metadata\", \"put\" for \"kepler:ens:example.eth://default/kv/public\". (4) \"credential\": \"present\" for \"urn:credential:type:type1\".",
+      "statement": "I further authorize the stated URI to perform the following actions on my behalf: (1) 'kv': 'get', 'list', 'metadata' for 'kepler:ens:example.eth://default/kv'. (2) 'kv': 'delete', 'get', 'list', 'metadata', 'put' for 'kepler:ens:example.eth://default/kv/dapp-space'. (3) 'kv': 'delete', 'get', 'list', 'metadata', 'put' for 'kepler:ens:example.eth://default/kv/public'. (4) 'credential': 'present' for 'urn:credential:type:type1'.",
       "uri": "did:key:example",
       "version": "1",
       "chainId": "1",
@@ -45,7 +45,7 @@
     "message": {
       "domain": "example.com",
       "address": "0x0000000000000000000000000000000000000000",
-      "statement": "Some custom statement. I further authorize the stated URI to perform the following actions on my behalf: (1) \"credential\": \"present\" for \"credential:*\".",
+      "statement": "Some custom statement. I further authorize the stated URI to perform the following actions on my behalf: (1) 'credential': 'present' for 'credential:*'.",
       "uri": "did:key:example",
       "version": "1",
       "chainId": "1",

--- a/test/valid.json
+++ b/test/valid.json
@@ -1,4 +1,34 @@
 {
+  "withCapsMessageString": {
+    "message": "example.com wants you to sign in with your Ethereum account:\n0x0000000000000000000000000000000000000000\n\nI further authorize the stated URI to perform the following actions on my behalf: (1) 'kv': 'get', 'list', 'metadata' for 'kepler:ens:example.eth://default/kv'. (2) 'kv': 'delete', 'get', 'list', 'metadata', 'put' for 'kepler:ens:example.eth://default/kv/dapp-space'. (3) 'kv': 'delete', 'get', 'list', 'metadata', 'put' for 'kepler:ens:example.eth://default/kv/public'. (4) 'credential': 'present' for 'urn:credential:type:type1'.\n\nURI: did:key:example\nVersion: 1\nChain ID: 1\nNonce: mynonce1\nIssued At: 2022-06-21T12:00:00.000Z\nResources:\n- urn:recap:eyJhdHQiOnsia2VwbGVyOmVuczpleGFtcGxlLmV0aDovL2RlZmF1bHQva3YiOnsia3YvZ2V0Ijpbe31dLCJrdi9saXN0Ijpbe31dLCJrdi9tZXRhZGF0YSI6W3t9XX0sImtlcGxlcjplbnM6ZXhhbXBsZS5ldGg6Ly9kZWZhdWx0L2t2L2RhcHAtc3BhY2UiOnsia3YvZGVsZXRlIjpbe31dLCJrdi9nZXQiOlt7fV0sImt2L2xpc3QiOlt7fV0sImt2L21ldGFkYXRhIjpbe31dLCJrdi9wdXQiOlt7fV19LCJrZXBsZXI6ZW5zOmV4YW1wbGUuZXRoOi8vZGVmYXVsdC9rdi9wdWJsaWMiOnsia3YvZGVsZXRlIjpbe31dLCJrdi9nZXQiOlt7fV0sImt2L2xpc3QiOlt7fV0sImt2L21ldGFkYXRhIjpbe31dLCJrdi9wdXQiOlt7fV19LCJ1cm46Y3JlZGVudGlhbDp0eXBlOnR5cGUxIjp7ImNyZWRlbnRpYWwvcHJlc2VudCI6W3t9XX19LCJwcmYiOltdfQ",
+    "recap": {
+      "att": {
+        "kepler:ens:example.eth://default/kv": {
+          "kv/get": [{}],
+          "kv/list": [{}],
+          "kv/metadata": [{}]
+        },
+        "kepler:ens:example.eth://default/kv/dapp-space": {
+          "kv/delete": [{}],
+          "kv/get": [{}],
+          "kv/list": [{}],
+          "kv/metadata": [{}],
+          "kv/put": [{}]
+        },
+        "kepler:ens:example.eth://default/kv/public": {
+          "kv/delete": [{}],
+          "kv/get": [{}],
+          "kv/list": [{}],
+          "kv/metadata": [{}],
+          "kv/put": [{}]
+        },
+        "urn:credential:type:type1": {
+          "credential/present": [{}]
+        }
+      },
+      "prf": []
+    }
+  },
   "withCaps": {
     "message": {
       "domain": "example.com",


### PR DESCRIPTION
# Why

tl;DR - Double quotes are not parseable by siwe-parser per the ABNF grammar specified in [siwe-parser](https://github.com/spruceid/siwe/tree/main/packages/siwe-parser).

Currently we are generating double quote marks `"` which is not part of the grammar that is specified in the siwe-parser library (https://github.com/spruceid/siwe/blob/main/packages/siwe-parser/lib/abnf.ts#L108-L112). The result is that, when I try to pass a SIWE message (with caps declared in the statement) as a string into `new SiweMessage()`, the parser is used and it throws an error saying the SIWE message doesn't conform to the ABNF / specified grammar. I've confirmed this with a new test case with an added `"` in the parsing_positive.json in your siwe package, as an MCVE.

The reason why the tests pass in recap-ts right now is because we're passing in an object into `new SiweMessage` so the parser is not used, and hence tests pass. Perhaps we should add some tests in recap-ts where the SIWE message is in the form of a string too.

# What

Use single quote marks instead.

Add test case for passing string to `new SiweMessage()` constructor.

# Testing

`yarn test`.